### PR TITLE
Update docker README.md to fix a typo in how to run tests

### DIFF
--- a/development/docker/README.md
+++ b/development/docker/README.md
@@ -22,7 +22,7 @@ You can quickly start developing or testing against the API with minimal configu
 
 * Minimally, you now need to [Create a user from the console](https://github.com/SpeciesFileGroup/taxonworks_doc/blob/archive/development/HOW-TO.md#create-a-user-from-the-console) or [Seed a project, users, and some data from the command line](https://github.com/SpeciesFileGroup/taxonworks_doc/blob/archive/development/HOW-TO.md#seed-a-project-users-and-some-data-from-the-command-line) or _Restore a database dump_ (see below)
 
-* To run tests first setup the test database with `docker-compose exec app bundle exec rails db:test:prepare` and then run `docker-compose exec bundle exec rake`.
+* To run tests first setup the test database with `docker-compose exec app bundle exec rails db:test:prepare` and then run `docker-compose exec app bundle exec rake`.
 ## Develop!
 
 ### Overview


### PR DESCRIPTION
The previous `docker-compose exec bundle exec rake` returns immediately with no output.